### PR TITLE
Deploy SimpleAPI to Maven repository

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,34 @@
+image: maven:3-jdk-9-slim
+
+cache:
+  paths:
+  - .m2/repository
+
+variables:
+  MAVEN_OPTS: "-Dmaven.repo.local=.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
+  MAVEN_CLI_OPTS: "--batch-mode --errors --fail-at-end --show-version -DinstallAtEnd=true -DdeployAtEnd=true"
+
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  script:
+  - apt update
+  - apt install wget -y
+  - wget https://gitlab.com/cubekrowd/mavenrepo/raw/master/build2.sh
+  - bash build2.sh
+  artifacts:
+    paths:
+    - "*.jar"
+
+deploy:
+  stage: deploy
+  script:
+  - apt update
+  - apt install wget -y
+  - wget https://gitlab.com/cubekrowd/mavenrepo/raw/master/deploy1.sh
+  - bash deploy1.sh
+  only:
+  - master

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # SimpleAPI
+
+
+
+
+
+
+
+
+## Maven Repository
+```
+    <repositories>
+        <repository>
+            <id>cubekrowd-repo</id>
+            <url>https://mavenrepo.cubekrowd.net/artifactory/repo/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <!-- SimpleAPI -->
+        <dependency>
+            <groupId>simple.brainsynder</groupId>
+            <artifactId>SimpleAPI</artifactId>
+            <version>3.8</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 
 ## Maven Repository
+[![pipeline status](https://gitlab.com/cubekrowd/mirror-simpleapi/badges/master/pipeline.svg)](https://gitlab.com/cubekrowd/mirror-simpleapi/commits/master)
 ```
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,19 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <distributionManagement>
+        <repository>
+            <id>cubekrowd-repo</id>
+            <name>cubekrowd-public-releases</name>
+            <url>https://mavenrepo.cubekrowd.net/artifactory/public-release-local/</url>
+        </repository>
+        <snapshotRepository>
+            <id>cubekrowd-repo</id>
+            <name>cubekrowd-public-snapshots</name>
+            <url>https://mavenrepo.cubekrowd.net/artifactory/public-snapshot-local/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <build>
         <finalName>${project.artifactId}</finalName>
         <resources>
@@ -35,6 +48,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.0.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This pull request configures the automatic deployment and the destination where maven should deploy the plugin to. It should not affect the development process at all. Our CI/CD setup will then regularly (at least once per hour but runs normally more often) check for updates. When a new commit is detected it will clone the repository and deploy it to the maven repository. Instructions has been added to the README.md how the plugin can be used as a dependency.